### PR TITLE
Fix `Trying to get property of non-object` in previews

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,3 +53,8 @@ All notable changes to `laravel-mail-editor` will be documented in this file.
 ## Version 1.1.7
 
 - Moving away templates metadata from DB to a JSON file to avoid production problems.
+
+## Version 1.1.10
+
+- Fixes issues #15, #16 
+- Adds the ability to have params mocked for a Mailable's constructor where a type isn't available

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "homepage": "https://github.com/Qoraiche/laravel-mail-editor",
     "keywords": ["Laravel", "mailEclipse", "mailable-editor", "laravel-mail", "laravel-mailable", "mailable", "markdown"],
     "require": {
-        "illuminate/support": "~5"
+        "illuminate/support": "~5",
+        "reecem/mocker": "1.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -15,6 +15,7 @@ use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionProperty;
 use RegexIterator;
+use ReeceM\Mocker\ReflectionMockery;
 
 class mailEclipse
 {
@@ -623,6 +624,11 @@ class mailEclipse
             $reflection = new ReflectionClass($mailable);
 
             $params = $reflection->getConstructor()->getParameters();
+            
+            /**
+             * Pass the $reflection instance
+             */
+            $mock = new ReflectionMockery($reflection);
 
             DB::beginTransaction();
 
@@ -686,9 +692,10 @@ class mailEclipse
 
 
                 } else {
-
-                    $filteredparams[] = $arg;
-
+                    /**
+                     * For all the things not found, mock it.
+                     */
+                    $filteredparams[] = $mock->get($arg);
                 }
 
             }


### PR DESCRIPTION
This adds a fix and the functionality to render mailable where a user has custom variables that don't necessarily have a type.

it would fix issues #15 and #16 and improve on the initial fix for issue #1

I extracted the fix to a separate package so that improvements can be done there and the functionality would be updated in versions of larval-mail-editor.

I have added the package to the composer file and set the version to 1.0.* as I see more patches to it initially than other SemVer minor and major edits.

I can confirm on my local machine that this works.

It basically checks the constructor for any calls to a parameter in the form of `$param->...`, it then builds an object that mocks that variable.

The mocked result uses the PHP magic methods for `__get, __set and __toString` allowing unknown properties to be called or set in the template or the constructor.

Please let me know if this is alright as a fix or if improvements would be preferred.
