### PR TITLE
Add mockery objects for non-typed mailable args

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,3 +53,8 @@ All notable changes to `laravel-mail-editor` will be documented in this file.
 ## Version 1.1.7
 
 - Moving away templates metadata from DB to a JSON file to avoid production problems.
+
+## Version 1.1.10
+
+- Fixes issues #15, #16 
+- Adds the ability to have params mocked for a Mailable's constructor where a type isn't available

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "homepage": "https://github.com/Qoraiche/laravel-mail-editor",
     "keywords": ["Laravel", "mailEclipse", "mailable-editor", "laravel-mail", "laravel-mailable", "mailable", "markdown"],
     "require": {
-        "illuminate/support": "~5"
+        "illuminate/support": "~5",
+        "reecem/mocker": "1.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -625,7 +625,7 @@ class mailEclipse
 
             $params = $reflection->getConstructor()->getParameters();
 		
-            $mock = new ReflectionMockery($reflection);
+            $mocked = new ReflectionMockery($reflection);
 
             DB::beginTransaction();
 
@@ -689,10 +689,11 @@ class mailEclipse
 
 
                 } else {
-                    /**
-                     * For all the things not found, mock it.
-                     */
-                    $filteredparams[] = $mock->get($arg);
+                    try {
+                        $filteredparams[] = $mocked->get($arg);
+                    } catch (\Exception $e) {
+                        $filteredparams[] = $arg;
+                    }
                 }
 
             }

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -15,6 +15,7 @@ use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionProperty;
 use RegexIterator;
+use ReeceM\Mocker\ReflectionMockery;
 
 class mailEclipse
 {
@@ -623,6 +624,11 @@ class mailEclipse
             $reflection = new ReflectionClass($mailable);
 
             $params = $reflection->getConstructor()->getParameters();
+            
+            /**
+             * Pass the $reflection instance
+             */
+            $mock = new ReflectionMockery($reflection);
 
             DB::beginTransaction();
 
@@ -686,9 +692,10 @@ class mailEclipse
 
 
                 } else {
-
-                    $filteredparams[] = $arg;
-
+                    /**
+                     * For all the things not found, mock it.
+                     */
+                    $filteredparams[] = $mock->get($arg);
                 }
 
             }


### PR DESCRIPTION
This adds the ReflectionMockery Class to the MailEclipse package to allow user entered values in the Mailable's `__constructor()` method to be resolved without breaking the preview.

This requires no edits by a user on their variables. 

This PR also uncovers a bug which will be referenced in another issue and PR as there is a solution for it. 

fixes #15 and fixes #16 as they were relating to the fact that they were unknown types to the package and rendered as normal vars.