### PR TITLE
fix: make markdown be blade compatible

### DIFF
--- a/src/Http/Controllers/MailablesController.php
+++ b/src/Http/Controllers/MailablesController.php
@@ -87,7 +87,10 @@ class MailablesController extends Controller
 
 		$viewPath = $request->has('template') ? $request->viewpath : base64_decode($request->viewpath);
 
-		if( mailEclipse::markdownedTemplateToView(true, $request->markdown, $viewPath, $template) ){
+		// ref https://regexr.com/4dflu
+		$bladeRenderable = preg_replace('/((?!{{.*?-)(&gt;)(?=.*?}}))/', '>', $request->markdown);
+
+		if( mailEclipse::markdownedTemplateToView(true, $bladeRenderable, $viewPath, $template) ){
 
 			return response()->json([
 			    'status' => 'ok',


### PR DESCRIPTION
This fixes and issue where the tinyMCE editor would take the blade directive `{{ $user->name }}` and then render the thing as this in the .blade.php file `{{ $user-&gt;name }}`. It is filtering out the > symbol with the html code, this does not get rendered in the PHP.

There are options on the net to disable tinyMCE's html cleaner thing, but that makes more problems. 

So what I did is add a `preg_replace` on the markdown var each time it is saved.

Here is a link to regexr for an example of the regex working. It leaves anything outside of the {{ }} alone.

[Clean tinyMCE for blade](https://regexr.com/4dflu) (edit link was made as a branch)

> The markdown to markdown doesn't need it
