### PR TITLE
Fix/type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ resources/views/draft/*
 !resources/views/draft/.gitkeep
 !resources/views/templates/.gitkeep
 .DS_Store
+/vendor

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -641,7 +641,7 @@ class mailEclipse
      * @param string $arg the argument string|array
      * @param array $params the reflection param list
      * 
-     * @return array
+     * @return array|string|\ReeceM\Mocker\Mocked
      */
     private static function getMissingParams($arg, $params)
     {


### PR DESCRIPTION
This is to correct an error when a PHP type cannot be mocked using the Mocker class. 

For reference the issue #52 

It will apply default values for the types `int`, `float` and `bool`.

This PR also removes the `/vendor` dir from git history as the gitignore was missing it

It also cleans up the Mocked class import to remove the searching class and just apply the straight Mocked class