### PR TITLE
fix: mailto had duplicated entries.

### DIFF
--- a/resources/views/sections/view-mailable.blade.php
+++ b/resources/views/sections/view-mailable.blade.php
@@ -52,7 +52,7 @@
 
 				    				<tr>
 	                                    <td class="table-fit font-weight-sixhundred">From</td>
-	                                    <td><a href="mailto:{{ collect($resource['data']->from)->first()['address'] }}{{ !collect($resource['data']->from)->isEmpty() ? collect($resource['data']->from)->first()['address'] : config('mail.from.address') }}" class="badge badge-info mr-1 font-weight-light">
+	                                    <td><a href="mailto:{{ !collect($resource['data']->from)->isEmpty() ? collect($resource['data']->from)->first()['address'] : config('mail.from.address') }}" class="badge badge-info mr-1 font-weight-light">
 	                                    	@if (!collect($resource['data']->from)->isEmpty())
 
                             					{{ collect($resource['data']->from)->first()['address'] }}
@@ -67,7 +67,7 @@
 
                                 	<tr>
 	                                    <td class="table-fit font-weight-sixhundred">Reply To</td>
-	                                    <td><a href="mailto:{{ collect($resource['data']->replyTo)->first()['address'] }}{{ !collect($resource['data']->replyTo)->isEmpty() ? collect($resource['data']->replyTo)->first()['address'] : config('mail.reply_to.address') }}" class="badge badge-info mr-1 font-weight-light">
+	                                    <td><a href="mailto:{{ !collect($resource['data']->replyTo)->isEmpty() ? collect($resource['data']->replyTo)->first()['address'] : config('mail.reply_to.address') }}" class="badge badge-info mr-1 font-weight-light">
 	                                    	@if (!collect($resource['data']->replyTo)->isEmpty())
 
                             					{{ collect($resource['data']->replyTo)->first()['address'] }}


### PR DESCRIPTION
I found during use that when previewing a mail the email address in the `mailto:` href would have the email address duplicated for the _To:_ and _From:_ info fields that are clickable to open a new mail window. 

This removes that extra output of the email string in the mailto href.

See the image below for the example problem
<img width="813" alt="Screen Shot 2019-10-14 at 19 15 55" src="https://user-images.githubusercontent.com/2767904/66770156-31984780-eeb7-11e9-8a2b-5f0d7f5a34c2.png">
