### PR TITLE
Fixes serialize error on line breaks

### DIFF
--- a/resources/views/sections/edit-mailable-template.blade.php
+++ b/resources/views/sections/edit-mailable-template.blade.php
@@ -310,7 +310,7 @@ var templateID = "template_view_{{ $name }}_{{ $templateData['template_name'] }}
             $.ajax({
                   method: "POST",
                   url: "{{ route('previewMarkdownView') }}",
-                  data: { markdown: plainText, namespace: '{{ addslashes($templateData['namespace']) }}', viewdata: "{{ serialize($templateData['view_data']) }}", name: '{{ $name }}' }
+                  data: { markdown: plainText, namespace: '{{ addslashes($templateData['namespace']) }}', viewdata: "{{ preg_replace("/\r\n/","<br />", serialize($templateData['view_data'])) }}", name: '{{ $name }}' }
                 
             }).done(function( HtmledTemplate ) {
                 preview.innerHTML = HtmledTemplate;
@@ -463,7 +463,7 @@ var templateID = "template_view_{{ $name }}_{{ $templateData['template_name'] }}
           data: { 
             markdown: plainText, 
             namespace: '{{ addslashes($templateData['namespace']) }}', 
-            viewdata: "{{ serialize($templateData['view_data']) }}", 
+            viewdata: "{{ preg_replace("/\r\n/","<br />", serialize($templateData['view_data'])) }}", 
             name: '{{ $name }}' 
           }
         


### PR DESCRIPTION
If the collection or model that you load into the specific mail template, contains linebreak `\n\f`, the template engine will fail with the following error:

> Uncaught SyntaxError: Invalid or unexpected token

This happens because inside the `edit-mailable-template.blade.php` file, when sending the ` viewdata` with AJAX, it also breaks the line here:

```php
"a:2:{i:0;a:3:{s:3:&quot;key&quot;;s:7:&quot;consols&quot;;s:5:&quot;value&quot;;O:29:&quot;Illuminate\Support\Collection&quot;:1:{s:8:&quot;*items&quot;;a:1:{s:7:&quot;consols&quot;;N;}}s:4:&quot;data&quot;;a:2:{s:4:&quot;type&quot;;s:10:&quot;collection&quot;;s:10:&quot;attributes&quot;;a:1:{s:7:&quot;consols&quot;;N;}}}i:1;a:3:{s:3:&quot;key&quot;;s:4:&quot;user&quot;;s:5:&quot;value&quot;;O:8:&quot;App\User&quot;:28:{s:11:&quot;*fillable&quot;;a:4:{i:0;s:4:&quot;name&quot;;i:1;s:5:&quot;email&quot;;i:2;s:8:&quot;password&quot;;i:3;s:9:&quot;signature&quot;;}s:9:&quot;*hidden&quot;;a:2:{i:0;s:8:&quot;password&quot;;i:1;s:14:&quot;remember_token&quot;;}s:8:&quot;*casts&quot;;a:1:{s:17:&quot;email_verified_at&quot;;s:8:&quot;datetime&quot;;}s:13:&quot;*connection&quot;;s:6:&quot;sqlsrv&quot;;s:8:&quot;*table&quot;;s:5:&quot;users&quot;;s:13:&quot;*primaryKey&quot;;s:2:&quot;id&quot;;s:10:&quot;*keyType&quot;;s:3:&quot;int&quot;;s:12:&quot;incrementing&quot;;b:1;s:7:&quot;*with&quot;;a:0:{}s:12:&quot;*withCount&quot;;a:0:{}s:10:&quot;*perPage&quot;;i:15;s:6:&quot;exists&quot;;b:1;s:18:&quot;wasRecentlyCreated&quot;;b:0;s:13:&quot;*attributes&quot;;a:9:{s:2:&quot;id&quot;;s:1:&quot;4&quot;;s:4:&quot;name&quot;;s:18:&quot;Oliver Busk Jensen&quot;;s:5:&quot;email&quot;;s:29:&quot;oliver.busk.jensen@dk.dsv.com&quot;;s:17:&quot;email_verified_at&quot;;N;s:8:&quot;password&quot;;s:60:&quot;$2y$10$qNGZXPfVgy.X8ntskCcIee5ACVT0Fvhvm1rk5r0GCPI6zRAoXxzzq&quot;;s:14:&quot;remember_token&quot;;N;s:9:&quot;signature&quot;;s:130:&quot;Best regards,

Oliver Busk Jensen
Senior IT Developer, 
```

As you can see in above example, there are line breaks. 

In this PR, `\r\n` are replaced with a `<br />` before the model/collection is serialized.