### PR TITLE
Read properties of the Mailable parent classes if the Mailable extend…

### DIFF
--- a/src/Http/Controllers/MailablesController.php
+++ b/src/Http/Controllers/MailablesController.php
@@ -134,7 +134,7 @@ class MailablesController extends Controller
 
     public function delete(Request $request)
     {
-        $mailableFile = config('maileclipse.mailables_dir').$request->mailablename.'.php';
+        $mailableFile = config('maileclipse.mailables_dir').'/'.$request->mailablename.'.php';
 
         if (file_exists($mailableFile)) {
             unlink($mailableFile);

--- a/src/Http/Controllers/MailablesController.php
+++ b/src/Http/Controllers/MailablesController.php
@@ -134,7 +134,7 @@ class MailablesController extends Controller
 
     public function delete(Request $request)
     {
-        $mailableFile = config('maileclipse.mailables_dir').'/'.$request->mailablename.'.php';
+        $mailableFile = config('maileclipse.mailables_dir').$request->mailablename.'.php';
 
         if (file_exists($mailableFile)) {
             unlink($mailableFile);

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -686,8 +686,9 @@ class mailEclipse
         $allProps = [];
 
         foreach ($properties as $prop) {
-            if ($prop->class == $data->getName() || $prop->class == get_parent_class($data->getName()) && !$prop->isStatic()) {
-                $allProps[] = $prop->name;
+            if ($prop->class == $data->getName() || $prop->class == get_parent_class($data->getName()) &&
+                    get_parent_class($data->getName()) != 'Illuminate\Mail\Mailable' && !$prop->isStatic()) {
+                        $allProps[] = $prop->name;
             }
         }
 

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -686,7 +686,7 @@ class mailEclipse
         $allProps = [];
 
         foreach ($properties as $prop) {
-            if ($prop->class == $data->getName()) {
+            if ($prop->class == $data->getName() || $prop->class == get_parent_class($data->getName()) && !$prop->isStatic()) {
                 $allProps[] = $prop->name;
             }
         }


### PR DESCRIPTION
Read properties of the Mailable parent classes if the Mailable extends a Mailable parent.

If it is required to extend the generated Mailable classes from a parent class to share some functionality and properties among the Mailables, the current version was not reading the properties of the parent class. So I changed the code to do that.