### PR TITLE
Fix: __toString ReflectionType deprecation

### DIFF
--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -655,15 +655,22 @@ class mailEclipse
          * Determine if a builtin type can be found.
          * Not a string or object as a Mocked::class can work there.
          *
-         * ->getType() needs to be cast to string to get the protected prop.
+         * getName() is undocumented alternative to casting to string.
+         * https://www.php.net/manual/en/class.reflectiontype.php#124658
+         *
+         * @var \ReflectionType $reflection
          */
-        $argType = (string) collect($params)->where('name', $arg)->first()->getType();
+        $reflection = collect($params)->where('name', $arg)->first();
 
-        $argType = self::TYPES[$argType] ?? null;
+        if (version_compare(phpversion(), '7.1.00', '>=')) {
+            $type = self::TYPES[$reflection->getName()] ?? null;
+        } else {
+            $type = self::TYPES[$reflection->__toString()] ?? null;
+        }
 
         try {
-            return ! is_null($argType)
-                    ? $argType
+            return ! is_null($type)
+                    ? $type
                     : new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());
         } catch (\Exception $e) {
             return $arg;

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -668,7 +668,7 @@ class mailEclipse
                 : null;
         } else {
             $type = ! is_null($reflection)
-                ? self::TYPES[$reflection->__toString()]
+                ? self::TYPES[/** @scrutinizer ignore-deprecated */ $reflection->__toString()]
                 : null;
         }
 

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -2,21 +2,21 @@
 
 namespace qoraiche\mailEclipse;
 
-use RegexIterator;
 use ErrorException;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use Illuminate\Mail\Markdown;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReeceM\Mocker\Mocked;
 use ReflectionClass;
 use ReflectionProperty;
-use ReeceM\Mocker\Mocked;
-use Illuminate\Support\Str;
-use Illuminate\Mail\Markdown;
-use RecursiveIteratorIterator;
-use RecursiveDirectoryIterator;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Container\Container;
-use Illuminate\Support\Facades\View;
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use RegexIterator;
 
 class mailEclipse
 {

--- a/src/mailEclipse.php
+++ b/src/mailEclipse.php
@@ -660,12 +660,16 @@ class mailEclipse
          *
          * @var \ReflectionType $reflection
          */
-        $reflection = collect($params)->where('name', $arg)->first();
+        $reflection = collect($params)->where('name', $arg)->first()->getType();
 
-        if (version_compare(phpversion(), '7.1.00', '>=')) {
-            $type = self::TYPES[$reflection->getName()] ?? null;
+        if (version_compare(phpversion(), '7.1', '>=')) {
+            $type = ! is_null($reflection)
+                ? self::TYPES[$reflection->getName()]
+                : null;
         } else {
-            $type = self::TYPES[$reflection->__toString()] ?? null;
+            $type = ! is_null($reflection)
+                ? self::TYPES[$reflection->__toString()]
+                : null;
         }
 
         try {


### PR DESCRIPTION
This PR will resolve the issue of the deprecated `__toString()` method on the `ReflectionType::class`.

This would fix #82.

The solution implemented is to account for versions of PHP where this package will be used, as the method is deprecated from version 7.1 and up, yet the method call that replaces it is not available in versions below that.

For this reason I have added a version check to switch between either calling the method `getName()` or casting the name with `__toString()`, this is done to be explicit about which method we calling.

Then the rest of the functionality remains the same, if there is a type that is `int, float, bool` the defaults from the maileclipse package will be returned to give the knowledge that the constructor params worked.

If they aren't they will be mocked to an object that will then be returned.

### Side note
I also changed the variable names so they weren't so vague and represented the data we were working with.