### PR TITLE
Fix/string error reflections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,21 +23,21 @@
     },
     "autoload": {
         "psr-4": {
-            "qoraiche\\mailEclipse\\": "src/"
+            "Qoraiche\\MailEclipse\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "qoraiche\\mailEclipse\\Tests\\": "tests"
+            "Qoraiche\\MailEclipse\\Tests\\": "tests"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "qoraiche\\mailEclipse\\mailEclipseServiceProvider"
+                "Qoraiche\\MailEclipse\\MailEclipseServiceProvider"
             ],
             "aliases": {
-                "mailEclipse": "qoraiche\\mailEclipse\\Facades\\mailEclipse"
+                "MailEclipse": "Qoraiche\\MailEclipse\\Facades\\MailEclipse"
             }
         }
     }

--- a/src/Console/VendorPublishCommand.php
+++ b/src/Console/VendorPublishCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace qoraiche\mailEclipse\Command;
+namespace Qoraiche\MailEclipse\Command;
 
 use Illuminate\Console\Command;
 
@@ -28,7 +28,7 @@ class VendorPublishCommand extends Command
     public function handle()
     {
         $this->call('vendor:publish', [
-            '--provider' => "qoraiche\mailEclipse\mailEclipseServiceProvider",
+            '--provider' => "Qoraiche\MailEclipse\MailEclipseServiceProvider",
         ]);
     }
 }

--- a/src/Facades/MailEclipse.php
+++ b/src/Facades/MailEclipse.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace qoraiche\mailEclipse\Facades;
+namespace Qoraiche\MailEclipse\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class mailEclipse extends Facade
+class MailEclipse extends Facade
 {
     /**
      * Get the registered name of the component.

--- a/src/Http/Controllers/MailablesController.php
+++ b/src/Http/Controllers/MailablesController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace qoraiche\mailEclipse\Http\Controllers;
+namespace Qoraiche\MailEclipse\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
-use qoraiche\mailEclipse\mailEclipse;
+use Qoraiche\MailEclipse\MailEclipse;
 
 class MailablesController extends Controller
 {
@@ -24,26 +24,26 @@ class MailablesController extends Controller
 
     public function index()
     {
-        $mailables = mailEclipse::getMailables();
+        $mailables = MailEclipse::getMailables();
 
         $mailables = (null !== $mailables) ? $mailables->sortBy('name') : collect([]);
 
-        return view(mailEclipse::$view_namespace.'::sections.mailables', compact('mailables'));
+        return view(MailEclipse::$view_namespace.'::sections.mailables', compact('mailables'));
     }
 
     public function createMailable(Request $request)
     {
-        return view(mailEclipse::$view_namespace.'::createmailable');
+        return view(MailEclipse::$view_namespace.'::createmailable');
     }
 
     public function generateMailable(Request $request)
     {
-        return mailEclipse::generateMailable($request);
+        return MailEclipse::generateMailable($request);
     }
 
     public function viewMailable($name)
     {
-        $mailable = mailEclipse::getMailable('name', $name);
+        $mailable = MailEclipse::getMailable('name', $name);
 
         if ($mailable->isEmpty()) {
             return redirect()->route('mailableList');
@@ -51,23 +51,23 @@ class MailablesController extends Controller
 
         $resource = $mailable->first();
 
-        return view(mailEclipse::$view_namespace.'::sections.view-mailable')->with(compact('resource'));
+        return view(MailEclipse::$view_namespace.'::sections.view-mailable')->with(compact('resource'));
     }
 
     public function editMailable($name)
     {
-        $templateData = mailEclipse::getMailableTemplateData($name);
+        $templateData = MailEclipse::getMailableTemplateData($name);
 
         if (! $templateData) {
             return redirect()->route('viewMailable', ['name' => $name]);
         }
 
-        return view(mailEclipse::$view_namespace.'::sections.edit-mailable-template', compact('templateData', 'name'));
+        return view(MailEclipse::$view_namespace.'::sections.edit-mailable-template', compact('templateData', 'name'));
     }
 
     public function templatePreviewError()
     {
-        return view(mailEclipse::$view_namespace.'::previewerror');
+        return view(MailEclipse::$view_namespace.'::previewerror');
     }
 
     public function parseTemplate(Request $request)
@@ -79,7 +79,7 @@ class MailablesController extends Controller
         // ref https://regexr.com/4dflu
         $bladeRenderable = preg_replace('/((?!{{.*?-)(&gt;)(?=.*?}}))/', '>', $request->markdown);
 
-        if (mailEclipse::markdownedTemplateToView(true, $bladeRenderable, $viewPath, $template)) {
+        if (MailEclipse::markdownedTemplateToView(true, $bladeRenderable, $viewPath, $template)) {
             return response()->json([
                 'status' => 'ok',
             ]);
@@ -92,12 +92,12 @@ class MailablesController extends Controller
 
     public function previewMarkdownView(Request $request)
     {
-        return mailEclipse::previewMarkdownViewContent(false, $request->markdown, $request->name, false, $request->namespace);
+        return MailEclipse::previewMarkdownViewContent(false, $request->markdown, $request->name, false, $request->namespace);
     }
 
     public function previewMailable($name)
     {
-        $mailable = mailEclipse::getMailable('name', $name);
+        $mailable = MailEclipse::getMailable('name', $name);
 
         if ($mailable->isEmpty()) {
             return redirect()->route('mailableList');
@@ -105,10 +105,10 @@ class MailablesController extends Controller
 
         $resource = $mailable->first();
 
-        if (! is_null(mailEclipse::handleMailableViewDataArgs($resource['namespace']))) {
+        if (! is_null(MailEclipse::handleMailableViewDataArgs($resource['namespace']))) {
             // $instance = new $resource['namespace'];
             //
-            $instance = mailEclipse::handleMailableViewDataArgs($resource['namespace']);
+            $instance = MailEclipse::handleMailableViewDataArgs($resource['namespace']);
         } else {
             $instance = new $resource['namespace'];
         }
@@ -125,11 +125,11 @@ class MailablesController extends Controller
 
                 return $html->render();
             } catch (\ErrorException $e) {
-                return view(mailEclipse::$view_namespace.'::previewerror', ['errorMessage' => $e->getMessage()]);
+                return view(MailEclipse::$view_namespace.'::previewerror', ['errorMessage' => $e->getMessage()]);
             }
         }
 
-        return view(mailEclipse::$view_namespace.'::previewerror', ['errorMessage' => 'No template associated with this mailable.']);
+        return view(MailEclipse::$view_namespace.'::previewerror', ['errorMessage' => 'No template associated with this mailable.']);
     }
 
     public function delete(Request $request)

--- a/src/Http/Controllers/TemplatesController.php
+++ b/src/Http/Controllers/TemplatesController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace qoraiche\mailEclipse\Http\Controllers;
+namespace Qoraiche\MailEclipse\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
-use qoraiche\mailEclipse\mailEclipse;
+use Qoraiche\MailEclipse\MailEclipse;
 
 class TemplatesController extends Controller
 {
@@ -19,53 +19,53 @@ class TemplatesController extends Controller
 
     public function index()
     {
-        $skeletons = mailEclipse::getTemplateSkeletons();
+        $skeletons = MailEclipse::getTemplateSkeletons();
 
-        $templates = mailEclipse::getTemplates();
+        $templates = MailEclipse::getTemplates();
 
-        return View(mailEclipse::$view_namespace.'::sections.templates', compact('skeletons', 'templates'));
+        return View(MailEclipse::$view_namespace.'::sections.templates', compact('skeletons', 'templates'));
     }
 
     public function new($type, $name, $skeleton)
     {
         $type = $type === 'html' ? $type : 'markdown';
 
-        $skeleton = mailEclipse::getTemplateSkeleton($type, $name, $skeleton);
+        $skeleton = MailEclipse::getTemplateSkeleton($type, $name, $skeleton);
 
-        return View(mailEclipse::$view_namespace.'::sections.create-template', compact('skeleton'));
+        return View(MailEclipse::$view_namespace.'::sections.create-template', compact('skeleton'));
     }
 
     public function view($templateslug = null)
     {
-        $template = mailEclipse::getTemplate($templateslug);
+        $template = MailEclipse::getTemplate($templateslug);
 
         if (is_null($template)) {
             return redirect()->route('templateList');
         }
 
-        return View(mailEclipse::$view_namespace.'::sections.edit-template', compact('template'));
+        return View(MailEclipse::$view_namespace.'::sections.edit-template', compact('template'));
     }
 
     public function create(Request $request)
     {
-        return mailEclipse::createTemplate($request);
+        return MailEclipse::createTemplate($request);
     }
 
     public function select(Request $request)
     {
-        $skeletons = mailEclipse::getTemplateSkeletons();
+        $skeletons = MailEclipse::getTemplateSkeletons();
 
-        return View(mailEclipse::$view_namespace.'::sections.new-template', compact('skeletons'));
+        return View(MailEclipse::$view_namespace.'::sections.new-template', compact('skeletons'));
     }
 
     public function previewTemplateMarkdownView(Request $request)
     {
-        return mailEclipse::previewMarkdownViewContent(false, $request->markdown, $request->name, true);
+        return MailEclipse::previewMarkdownViewContent(false, $request->markdown, $request->name, true);
     }
 
     public function delete(Request $request)
     {
-        if (mailEclipse::deleteTemplate($request->templateslug)) {
+        if (MailEclipse::deleteTemplate($request->templateslug)) {
             return response()->json([
                 'status' => 'ok',
             ]);
@@ -78,6 +78,6 @@ class TemplatesController extends Controller
 
     public function update(Request $request)
     {
-        return mailEclipse::updateTemplate($request);
+        return MailEclipse::updateTemplate($request);
     }
 }

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace qoraiche\mailEclipse;
+namespace Qoraiche\MailEclipse;
 
 use ErrorException;
 use Illuminate\Container\Container;
@@ -18,7 +18,7 @@ use ReflectionClass;
 use ReflectionProperty;
 use RegexIterator;
 
-class mailEclipse
+class MailEclipse
 {
     public static $view_namespace = 'maileclipse';
 

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -680,7 +680,7 @@ class MailEclipse
             $reflectionType = /** @scrutinizer ignore-deprecated */ $reflection->__toString();
         }
 
-        return isset(self::TYPES[$reflectionType])
+        return array_key_exists($reflectionType, self::TYPES)
             ? self::TYPES[$reflectionType]
             : $reflectionType;
     }

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -29,7 +29,7 @@ class MailEclipse
      */
     public const TYPES = [
         'int'    => 31,
-        // 'string' => "Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton()) instance",
+        'string' => null,
         'bool'   => false,
         'float'  =>  3.14159,
     ];
@@ -626,7 +626,11 @@ class MailEclipse
                     }
                 } else {
                     try {
-                        $filteredparams[] = self::getMissingParams($arg, $params);
+
+                        $missingParam = self::getMissingParams($arg, $params);
+                        $filteredparams[] = is_null($missingParam)
+                            ? new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton())
+                            : $missingParam;
                     } catch (\Exception $error) {
                         $filteredparams[] = $arg;
                     }
@@ -677,7 +681,7 @@ class MailEclipse
         }
 
         return isset(self::TYPES[$reflectionType])
-            ? self::TYPES[$reflectionType]($arg)
+            ? self::TYPES[$reflectionType]
             : $reflectionType;
     }
 

--- a/src/MailEclipseServiceProvider.php
+++ b/src/MailEclipseServiceProvider.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace qoraiche\mailEclipse;
+namespace Qoraiche\MailEclipse;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use qoraiche\mailEclipse\Command\VendorPublishCommand;
+use Qoraiche\MailEclipse\Command\VendorPublishCommand;
 
-class mailEclipseServiceProvider extends ServiceProvider
+class MailEclipseServiceProvider extends ServiceProvider
 {
     /**
      * Perform post-registration booting of services.
@@ -47,7 +47,7 @@ class mailEclipseServiceProvider extends ServiceProvider
     private function routeConfiguration()
     {
         return [
-            'namespace' => 'qoraiche\mailEclipse\Http\Controllers',
+            'namespace' => 'Qoraiche\MailEclipse\Http\Controllers',
             'prefix' => config('maileclipse.path'),
             'middleware' => 'maileclipse',
         ];
@@ -64,7 +64,7 @@ class mailEclipseServiceProvider extends ServiceProvider
 
         // Register the service the package provides.
         $this->app->singleton('maileclipse', function ($app) {
-            return new mailEclipse;
+            return new MailEclipse;
         });
     }
 


### PR DESCRIPTION
This is to fix the `string` type hint on constructor arguments.

The idea behind this is that it would return a mocked object that would give the name of the string that was passed so that end users know what it was. And not have a single repeated string all over the show.

Would close #103 