### PR TITLE
Fix - Issue 137

### DIFF
--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -824,6 +824,8 @@ class MailEclipse
                 'attributes' => $param->all(),
             ];
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
[#137 ](https://github.com/Qoraiche/laravel-mail-editor/issues/137)

Class members simply that did not meet `instanceof` requirements wouldn't return anything.