### PR TITLE
fix: restore missing logic in parameter resolution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -159,3 +159,23 @@ see #107, #106
 ### Addition
 - Revert Laravel 8 support
 - Console command for installing assets see PR #111
+
+## Version 2.2.1
+Patch Release.
+
+### Fixes
+
+- Fixes  the string error that happens when the constructor params have a string type hint, issue #103
+see #113
+
+## Version 2.2.2
+This is a patch release of the package for a PSR-4 warning
+
+### Fix
+
+- The namespace and the file structure of the console command were corrected to PSR-4 standards thanks @ivebe, see #115
+
+
+## Version 2.2.3
+### Fix
+- port version 3 fix back into v2, see #140, #141

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -673,7 +673,7 @@ class MailEclipse
         }
 
         try {
-            return !is_null($type)
+            return ! is_null($type)
                 ? $type
                 : new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());
         } catch (\Exception $e) {

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -649,23 +649,23 @@ class MailEclipse
      */
     private static function getMissingParams($arg, $params)
     {
-        /** 
-         * Determine if a builtin type can be found. 
-         * Not a string or object as a Mocked::class can work there. 
-         * 
-         * getName() is undocumented alternative to casting to string. 
-         * https://www.php.net/manual/en/class.reflectiontype.php#124658 
-         * 
-         * @var \ReflectionType $reflection 
+        /**
+         * Determine if a builtin type can be found.
+         * Not a string or object as a Mocked::class can work there.
+         *
+         * getName() is undocumented alternative to casting to string.
+         * https://www.php.net/manual/en/class.reflectiontype.php#124658
+         *
+         * @var \ReflectionType $reflection
          */
         $reflection = collect($params)->where('name', $arg)->first()->getType();
 
         if (version_compare(phpversion(), '7.1', '>=')) {
-            $type = !is_null($reflection)
+            $type = ! is_null($reflection)
                 ? self::TYPES[$reflection->getName()]
                 : null;
         } else {
-            $type = !is_null($reflection)
+            $type = ! is_null($reflection)
                 ? self::TYPES[
                 /** @scrutinizer ignore-deprecated */
                 $reflection->__toString()]
@@ -679,7 +679,7 @@ class MailEclipse
         } catch (\Exception $e) {
             return $arg;
         }
-    } 
+    }
 
     private static function getMailableViewData($mailable, $mailable_data)
     {


### PR DESCRIPTION
See the issue #140 for a discussion of what lead to this realization 🤣 

Target version: v2, resulting tag v2.2.3

But basically it is back porting version 3 fixes for the missing parameter resolution that solved the issue of the null result from the reflection checks.

The fix also removes a bit of code from one section as it moves to the function.
