### PR TITLE
Fix/issue 63 loading relations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -189,3 +189,32 @@ Laravel 8 Support release
 ## Potential Breaking Change
 
 The name spaces of the package now use PSR classname standards, if you were referencing them before in an application, please update them to reflect everything correctly.
+
+## Unreleased: Version 3.4.0
+
+This release will resolve the issue that has been brought up in issue #63 where relations weren't being loaded and affected the calling of relations inside emails or mailables.
+
+## Fixes
+- Fixes issue [#63](https://github.com/Qoraiche/laravel-mail-editor/issues/63)
+
+## Addition
+- Discovery and loading of relations that have factories
+- New config for depth of searching see below for new addition
+
+**new config value**
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Relationship loading depth
+    |--------------------------------------------------------------------------
+    |
+    | This configures how deep the package will search an load relations.
+    | If you set this to 0, relations will not be loaded.
+    |
+    | off = 0, min = 1, max = 5
+    |
+    | N.B. This does not configure how many many relationship types are loaded.
+    */
+
+    'relation_depth' => env('MAILECLIPSE_RELATION_DEPTH', 2),
+```

--- a/config/maileclipse.php
+++ b/config/maileclipse.php
@@ -34,6 +34,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Relationship loading depth
+    |--------------------------------------------------------------------------
+    |
+    | This configures how deep the package will search an load relations.
+    | If you set this to 0, relations will not be loaded.
+    |
+    | off = 0, min = 1, max = 5
+    |
+    | N.B. This does not configure how many many relationship types are loaded.
+    */
+
+    'relation_depth' => env('MAILECLIPSE_RELATION_DEPTH', 2),
+
+    /*
+    |--------------------------------------------------------------------------
     | Environment
     |--------------------------------------------------------------------------
     |

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -4,6 +4,7 @@ namespace Qoraiche\MailEclipse;
 
 use ErrorException;
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Mail\Markdown;
 use Illuminate\Support\Collection;


### PR DESCRIPTION
This PR adds the ability for the package to search and load model relations using the factory methods, or using the Mocker class to ensure that at least the value isn't null if there is more than 1 call to the property.

Will fix issue #63 

There shouldn't be breaking changes with this as it extends the current functionality of there Factory resolver method and defaults to it's original value if it fails.


**new config value**
```php
config/maileclipse.php
    /*
    |--------------------------------------------------------------------------
    | Relationship loading depth
    |--------------------------------------------------------------------------
    |
    | This configures how deep the package will search an load relations.
    | If you set this to 0, relations will not be loaded.
    |
    | off = 0, min = 1, max = 5
    |
    | N.B. This does not configure how many many relationship types are loaded.
    */

    'relation_depth' => env('MAILECLIPSE_RELATION_DEPTH', 2),
```
