### PR TITLE
add tests for environment restriction responses

### DIFF
--- a/src/Http/Controllers/MailablesController.php
+++ b/src/Http/Controllers/MailablesController.php
@@ -13,7 +13,8 @@ class MailablesController extends Controller
     {
         abort_unless(
             App::environment(config('maileclipse.allowed_environments', ['local'])),
-            403
+            403,
+            'Environment Not Allowed'
       );
     }
 

--- a/src/Http/Controllers/TemplatesController.php
+++ b/src/Http/Controllers/TemplatesController.php
@@ -14,7 +14,8 @@ class TemplatesController extends Controller
     {
         abort_unless(
             App::environment(config('maileclipse.allowed_environments', ['local'])),
-            403
+            403,
+            'Environment Not Allowed'
         );
     }
 

--- a/tests/Feature/MailablesControllerTest.php
+++ b/tests/Feature/MailablesControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Qoraiche\MailEclipse\Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Qoraiche\MailEclipse\Tests\TestCase as TestCase;
+
+class MailablesControllerTest extends TestCase
+{
+    public function test_page_loads_in_allowed_environments()
+    {
+        Config::set('maileclipse.allowed_environments', ['staging', 'testing', 'local']);
+
+        $this->get('maileclipse/mailables')
+            ->assertOk();
+    }
+
+    public function test_returns_error_when_viewing_in_prohibited_env_by_default()
+    {
+        Config::set('maileclipse.allowed_environments', ['staging', 'local']);
+
+        $this->get('maileclipse/mailables')
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/MailablesControllerTest.php
+++ b/tests/Feature/MailablesControllerTest.php
@@ -3,7 +3,7 @@
 namespace Qoraiche\MailEclipse\Tests\Feature;
 
 use Illuminate\Support\Facades\Config;
-use Qoraiche\MailEclipse\Tests\TestCase as TestCase;
+use Qoraiche\MailEclipse\Tests\TestCase;
 
 class MailablesControllerTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Qoraiche\MailEclipse\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Qoraiche\MailEclipse\MailEclipseServiceProvider;
+
+class TestCase extends Orchestra
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            MailEclipseServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+}


### PR DESCRIPTION
This ports the fix from the v2 branch that adds some tests to confirm the correct response is given when environments don't match.