### PR TITLE
fix: for issue #178 🐛

### DIFF
--- a/src/Actions/CreateMailable.php
+++ b/src/Actions/CreateMailable.php
@@ -11,7 +11,7 @@ class CreateMailable
     /**
      * Handle Creating a new mailable.
      *
-     * @param  array $parameters
+     * @param  array  $parameters
      * @return string[]
      */
     public function handle(array $parameters)
@@ -50,7 +50,7 @@ class CreateMailable
     /**
      * Get the parameters for the artisan command.
      *
-     * @param  array $parameters
+     * @param  array  $parameters
      * @return array
      */
     protected function commandParameters(array $parameters)

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -39,9 +39,11 @@ class MailEclipse
      */
     public const TYPES = [
         'int' => 31,
-        // 'string' => 'test_string', // not needed as it can be cast __toString()
+        'string' => null,
         'bool' => false,
         'float' => 3.14159,
+        'iterable' => null,
+        'array' => null,
     ];
 
     public static $traversed = 0;
@@ -638,24 +640,23 @@ class MailEclipse
          * getName() is undocumented alternative to casting to string.
          * https://www.php.net/manual/en/class.reflectiontype.php#124658
          *
-         * @var \ReflectionType $reflection
+         * @var \ReflectionNamedType|null $reflection
          */
-        $reflection = collect($params)->where('name', $arg)->first()->getType();
-
-        if (version_compare(phpversion(), '7.1', '>=')) {
-            $type = ! is_null($reflection)
-                ? self::TYPES[$reflection->getName()]
-                : null;
-        } else {
-            $type = ! is_null($reflection)
-                ? self::TYPES[/** @scrutinizer ignore-deprecated */ $reflection->__toString()]
-                : null;
-        }
+        $reflection = collect($params)->where('name', $arg)->first()->getType() ?? null;
 
         try {
-            return ! is_null($type)
-                    ? $type
-                    : new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());
+
+            if (is_null($reflection)) {
+                return new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());;
+            }
+
+            $type = version_compare(phpversion(), '7.1', '>=')
+                ? self::TYPES[$reflection->getName()]
+                : self::TYPES[/** @scrutinizer ignore-deprecated */ $reflection->__toString()];
+
+            return is_null($type)
+                ? new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton())
+                : $type;
         } catch (\Exception $e) {
             return $arg;
         }

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -50,6 +50,7 @@ class MailEclipse
 
     /**
      * @return array
+     *
      * @throws \ReflectionException
      */
     public static function getMailables()
@@ -61,6 +62,7 @@ class MailEclipse
      * @param $key
      * @param $name
      * @return Collection
+     *
      * @throws \ReflectionException
      */
     public static function getMailable($key, $name): Collection
@@ -121,7 +123,7 @@ class MailEclipse
     /**
      * Save templates to templates.json file.
      *
-     * @param Collection $templates
+     * @param  Collection  $templates
      */
     public static function saveTemplates(Collection $templates): void
     {
@@ -315,9 +317,10 @@ class MailEclipse
      * @param $simpleview
      * @param $content
      * @param $viewName
-     * @param bool $template
-     * @param null $namespace
+     * @param  bool  $template
+     * @param  null  $namespace
      * @return bool|string|void
+     *
      * @throws \ReflectionException
      */
     public static function previewMarkdownViewContent($simpleview, $content, $viewName, $template = false, $namespace = null)
@@ -387,7 +390,7 @@ class MailEclipse
     }
 
     /**
-     * @param null $request
+     * @param  null  $request
      * @return JsonResponse
      */
     public static function generateMailable($request = null): JsonResponse
@@ -448,6 +451,7 @@ class MailEclipse
      * Get Mailables list.
      *
      * @return array
+     *
      * @throws \ReflectionException
      */
     protected static function mailablesList()
@@ -550,8 +554,10 @@ class MailEclipse
 
     /**
      * Handle Mailable Constructor arguments and pass the fake ones.
+     *
      * @param $mailable
      * @return object|void
+     *
      * @throws \ReflectionException
      */
     public static function handleMailableViewDataArgs($mailable)
@@ -626,9 +632,8 @@ class MailEclipse
     /**
      * Gets any missing params that may not be collectable in the reflection.
      *
-     * @param string $arg the argument string|array
-     * @param array $params the reflection param list
-     *
+     * @param  string  $arg  the argument string|array
+     * @param  array  $params  the reflection param list
      * @return array|string|\ReeceM\Mocker\Mocked
      */
     private static function getMissingParams($arg, $params)
@@ -645,9 +650,8 @@ class MailEclipse
         $reflection = collect($params)->where('name', $arg)->first()->getType() ?? null;
 
         try {
-
             if (is_null($reflection)) {
-                return new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());;
+                return new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());
             }
 
             $type = version_compare(phpversion(), '7.1', '>=')
@@ -666,6 +670,7 @@ class MailEclipse
      * @param $mailable
      * @param $mailable_data
      * @return array|Collection
+     *
      * @throws \ReflectionException
      */
     private static function getMailableViewData($mailable, $mailable_data)
@@ -761,6 +766,7 @@ class MailEclipse
     /**
      * @param $mailable
      * @return mixed|void
+     *
      * @throws \ReflectionException
      */
     protected static function getMarkdownViewName($mailable)
@@ -780,8 +786,9 @@ class MailEclipse
 
     /**
      * @param $instance
-     * @param string $type
+     * @param  string  $type
      * @return mixed
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \ReflectionException
      */
@@ -801,9 +808,10 @@ class MailEclipse
     /**
      * @param $simpleview
      * @param $view
-     * @param bool $template
-     * @param null $instance
+     * @param  bool  $template
+     * @param  null  $instance
      * @return string|void
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \ReflectionException
      */
@@ -901,7 +909,6 @@ class MailEclipse
      *
      * @param $eloquentFactory
      * @param $model
-     *
      * @return null|object
      */
     private static function resolveFactory($eloquentFactory, $model): ?object
@@ -929,9 +936,8 @@ class MailEclipse
      * single level relation resolving for a model.
      * It will load the relations or set to mocked class.
      *
-     * @param mixed $eloquentFactory
-     * @param mixed $factoryModel
-     *
+     * @param  mixed  $eloquentFactory
+     * @param  mixed  $factoryModel
      * @return null|object
      */
     private static function hydrateRelations($eloquentFactory, $factoryModel): ?object
@@ -977,10 +983,9 @@ class MailEclipse
      *
      * @todo Account for the many type relations, link back to parent model for belongsTo
      *
-     * @param mixed $relationName
-     * @param mixed $factoryModel
-     * @param mixed|null $eloquentFactory
-     *
+     * @param  mixed  $relationName
+     * @param  mixed  $factoryModel
+     * @param  mixed|null  $eloquentFactory
      * @return null|object
      */
     public static function loadRelations($relationName, $factoryModel, $eloquentFactory = null): ?object
@@ -1027,8 +1032,9 @@ class MailEclipse
     }
 
     /**
-     * @param string $name
+     * @param  string  $name
      * @return bool|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+     *
      * @throws \ReflectionException
      */
     public static function renderMailable(string $name)
@@ -1051,8 +1057,8 @@ class MailEclipse
     }
 
     /**
-     * @param string $name
-     * @param string $recipient
+     * @param  string  $name
+     * @param  string  $recipient
      */
     public static function sendTest(string $name, string $recipient): void
     {
@@ -1067,7 +1073,7 @@ class MailEclipse
 
     /**
      * @param $mailable
-     * @param string $email
+     * @param  string  $email
      * @return mixed
      */
     public static function setMailableSendTestRecipient($mailable, string $email)
@@ -1082,6 +1088,7 @@ class MailEclipse
     /**
      * @param $mailable
      * @return object|void
+     *
      * @throws \ReflectionException
      */
     private static function resolveMailableInstance($mailable)

--- a/src/Utils/Replacer.php
+++ b/src/Utils/Replacer.php
@@ -49,7 +49,7 @@ class Replacer
     /**
      * Take the format of the Blade syntax and convert to one the editor understands.
      *
-     * @param mixed $content
+     * @param  mixed  $content
      * @return string|string[]|null
      */
     public static function toEditor($content)
@@ -62,7 +62,7 @@ class Replacer
     /**
      * Take the data from the editor and return a format that the Blade syntax.
      *
-     * @param mixed $content
+     * @param  mixed  $content
      * @return string|string[]|null
      */
     public static function toBlade($content): string
@@ -75,9 +75,9 @@ class Replacer
     /**
      * Replace the content with the patterns and targeted format.
      *
-     * @param array $patterns
-     * @param array $replacements
-     * @param mixed $content
+     * @param  array  $patterns
+     * @param  array  $replacements
+     * @param  mixed  $content
      * @return string|string[]|null
      */
     protected function replace(array $patterns, array $replacements, $content)
@@ -91,6 +91,7 @@ class Replacer
      * This also ensures that the replace array is the same length as the match array
      *
      * @return void
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function generateRegex()

--- a/src/Utils/TemplateSkeletons.php
+++ b/src/Utils/TemplateSkeletons.php
@@ -20,9 +20,9 @@ class TemplateSkeletons
     }
 
     /**
-     * @param mixed $type
-     * @param mixed $name
-     * @param mixed $skeleton
+     * @param  mixed  $type
+     * @param  mixed  $name
+     * @param  mixed  $skeleton
      * @return array|void
      */
     public static function get($type, $name, $skeleton)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This changes the order and process the resolving takes place for `getMissingParams` function. It also makes it default to returning a mockable object for the string type and others should they be type hinted

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #178 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This is a relatively recurring issue in some instances. (I thought to have been fixed)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed instance was tested. Doesn't change internal interface of the code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [z] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.