### PR TITLE
Fix/newline issue with factory data

### DIFF
--- a/resources/views/sections/edit-mailable-template.blade.php
+++ b/resources/views/sections/edit-mailable-template.blade.php
@@ -341,10 +341,14 @@ var templateID = "template_view_{{ $name }}_{{ $templateData['template_name'] }}
         placeholder: "Write your Beautiful Email",
         previewRender: function(plainText, preview) {
             $.ajax({
-                  method: "POST",
-                  url: "{{ route('previewMarkdownView') }}",
-                  data: { markdown: plainText, namespace: '{{ addslashes($templateData['namespace']) }}', viewdata: "{{ preg_replace("/\r\n/","<br />", serialize($templateData['view_data'])) }}", name: '{{ $name }}' }
-
+                method: "POST",
+                url: "{{ route('previewMarkdownView') }}",
+                data: {
+                    markdown: plainText,
+                    namespace: '{{ addslashes($templateData['namespace']) }}',
+                    viewdata: "{{ preg_replace("/[\r\n]/","<br />", serialize($templateData['view_data'])) }}",
+                    name: '{{ $name }}'
+                }
             }).done(function( HtmledTemplate ) {
                 preview.innerHTML = HtmledTemplate;
             });
@@ -496,7 +500,7 @@ var templateID = "template_view_{{ $name }}_{{ $templateData['template_name'] }}
           data: {
             markdown: plainText,
             namespace: '{{ addslashes($templateData['namespace']) }}',
-            viewdata: "{{ preg_replace("/\r\n/","<br />", serialize($templateData['view_data'])) }}",
+            viewdata: "{{ preg_replace("/[\r\n]/","<br />", serialize($templateData['view_data'])) }}",
             name: '{{ $name }}'
           }
 

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -654,12 +654,12 @@ class MailEclipse
             }
 
             $type = version_compare(phpversion(), '7.1', '>=')
-                ? self::TYPES[$reflection->getName()]
-                : self::TYPES[/** @scrutinizer ignore-deprecated */ $reflection->__toString()];
+                ? $reflection->getName()
+                : /** @scrutinizer ignore-deprecated */ $reflection->__toString();
 
-            return is_null($type)
-                ? new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton())
-                : $type;
+            return array_key_exists($type, self::TYPES)
+                ? self::TYPES[$type]
+                : new Mocked($arg, \ReeceM\Mocker\Utils\VarStore::singleton());
         } catch (\Exception $e) {
             return $arg;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change makes the regex capture all the variations of the `\r\n` special characters for replacing with the `preg_replace` function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#187 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes the issue that caused the TinyMCE editor to crash due to an error in the Javascript code that was rendered in the view. The issue came from the fact that there was a newline that got into the final string.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, the PR has been tested locally and in a project.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.