### PR TITLE
fix : create mailables class in custom mail directory

### DIFF
--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -395,6 +395,10 @@ class MailEclipse
     public static function generateMailable($request = null): JsonResponse
     {
         $name = self::generateClassName($request->input('name'));
+        $defaultDirectory = 'Mail';
+
+        $mailableDir = config('maileclipse.mailables_dir');
+        $customPath = substr($mailableDir,strpos($mailableDir,$defaultDirectory) + strlen($defaultDirectory) + 1);
 
         if ($name === false) {
             return response()->json([
@@ -416,6 +420,8 @@ class MailEclipse
                 'message' => 'You cannot use "mailable" as a mailable name',
             ]);
         }
+
+        $name = $customPath ? $customPath.'/'.$name : $name;
 
         $params = collect([
             'name' => $name,

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -398,7 +398,7 @@ class MailEclipse
         $defaultDirectory = 'Mail';
 
         $mailableDir = config('maileclipse.mailables_dir');
-        $customPath = substr($mailableDir,strpos($mailableDir,$defaultDirectory) + strlen($defaultDirectory) + 1);
+        $customPath = substr($mailableDir, strpos($mailableDir, $defaultDirectory) + strlen($defaultDirectory) + 1);
 
         if ($name === false) {
             return response()->json([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix creating mail class with custom directory

## Description
<!--- Describe your changes in detail -->
While updating config file to 'mailables_dir' => app_path('Mail/Templates'), mailables are not creating in Mail/Templates directory.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
