### PR TITLE
fix: compatible way to call the method on mailable

### DIFF
--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -553,7 +553,10 @@ class MailEclipse
             $collection = collect($fqcns)->map(function ($mailable) {
                 return $mailable;
             })->reject(function ($object) {
-                return ! method_exists($object['namespace'], 'build');
+                return ! array_search(
+                    'Illuminate\Contracts\Mail\Mailable',
+                    class_implements($object['namespace']
+                ));
             });
 
             return $collection;
@@ -810,7 +813,7 @@ class MailEclipse
 
         if ($type === 'call') {
             if (self::handleMailableViewDataArgs($instance) !== null) {
-                return app()->call([self::handleMailableViewDataArgs($instance), $method]);
+                return self::handleMailableViewDataArgs($instance);
             }
 
             if ($method == 'content') {

--- a/src/MailEclipse.php
+++ b/src/MailEclipse.php
@@ -802,12 +802,14 @@ class MailEclipse
      */
     public static function buildMailable($instance, $type = 'call')
     {
+        $method = method_exists($instance, 'build') ? 'build' : 'render';
+
         if ($type === 'call') {
             if (self::handleMailableViewDataArgs($instance) !== null) {
-                return app()->call([self::handleMailableViewDataArgs($instance), 'build']);
+                return app()->call([self::handleMailableViewDataArgs($instance), $method]);
             }
 
-            return app()->call([new $instance, 'build']);
+            return app()->call([new $instance, $method]);
         }
 
         return app()->make($instance);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a method exists check to the function of the buildMailable data method to check which method exists on the Mailable. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#218 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This is to make the preview functionality work with Laravel 9

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

